### PR TITLE
fix: :bug: "Atualizei os signals do usuário para que, ao alterar o email, o nome de usuário e o email do django_user também sejam atualizados.

### DIFF
--- a/{{cookiecutter.project_slug}}/usuario/models.py
+++ b/{{cookiecutter.project_slug}}/usuario/models.py
@@ -49,17 +49,5 @@ class Usuario(Base):
         fields_display = ["nome", "email", "telefone", "endereco"]
         icon_model = "fas fa-user"
 
-    def save(self, *args, **kwargs):
-        # Checa se o email foi alterado
-        # para modificar o Django User no Signal
-        if not self._state.adding:
-            old = Usuario.objects.get(pk=self.pk)
-            if old.email != self.email:
-                old.django_user.is_active = False
-                old.django_user.save()
-                self.django_user = None
-                self.token = None
-        super().save(*args, **kwargs)
-
     def __str__(self):
         return f"Usuario: {self.cpf} | {self.email}"

--- a/{{cookiecutter.project_slug}}/usuario/signals.py
+++ b/{{cookiecutter.project_slug}}/usuario/signals.py
@@ -63,6 +63,18 @@ def signal_save_usuario_django(sender, instance, created, **kwargs):
 
         except Exception as error:
             print(f"Erro ao Inativar o DjangoUser: {error}")
+    
+    # Modifica o username e email do django_user quando o usuário altera o email dele 
+    elif instance.email and not User.objects.filter(username=instance.email).exists():
+        try:
+            with transaction.atomic():
+                if django_user := User.objects.filter(pk=instance.django_user.pk).first():
+                    django_user.username = instance.email
+                    django_user.email = instance.email
+                    django_user.save()
+
+        except Exception as error:
+            print(f"Erro ao atribuir/alterar o username e o email: {error}")
 
 
 @receiver(post_delete, sender=Usuario)


### PR DESCRIPTION
A seguinte correção está relacionada à questão em que o usuário realiza uma alteração no seu email, e isso acarreta na necessidade de também modificar tanto o email quanto o nome de usuário (username) no django_user. O motivo para essa abordagem está vinculado à manipulação do método save no modelo de usuário. Originalmente, esse método era empregado para definir o valor do atributo django_user do respectivo usuário como falso (false), efetivamente desativando o usuário criado. No entanto, essa estratégia apresentou algumas limitações, como a persistência do usuário antigo na lista geral de usuários.
Portanto, foi decidido remover o método save do modelo, adotando uma nova abordagem por meio do signals que tais foram reescritos de modo a permitir a atualização do nome de usuário e email quando um usuário modificar o seu endereço de email. Isso garante uma sincronização adequada entre as informações do usuário e evita problemas como a exibição do usuário antigo na lista de todos os usuários.